### PR TITLE
Fix man page warnings: macro `"' not defined.

### DIFF
--- a/doc/man/h5fromh4.1
+++ b/doc/man/h5fromh4.1
@@ -27,7 +27,7 @@ h5fromh4 \- convert HDF4 scientific datasets to an HDF5 file
 [\fIOPTION\fR]... [\fIHDF4FILE\fR]...
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5fromh4 takes one or more files in HDF4 format and outputs files in
 HDF5 format containing the datasets from the HDF4 files.  (Currently,
 only a single dataset per HDF4 file is converted.)

--- a/doc/man/h5fromtxt.1
+++ b/doc/man/h5fromtxt.1
@@ -27,7 +27,7 @@ h5fromtxt \- convert text input to an HDF5 file
 [\fIOPTION\fR]... [\fIHDF5FILE\fR]
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5fromtxt takes a series of numbers from standard input and outputs a
 multi-dimensional numeric dataset in an HDF5 file.
 

--- a/doc/man/h5math.1
+++ b/doc/man/h5math.1
@@ -27,7 +27,7 @@ h5math \- combine/create HDF5 files with math expressions
 [\fIOPTION\fR]... \fIOUTPUT-HDF5FILE\fR [\fIINPUT-HDF5FILES\fR...]
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5math takes any number of HDF5 files as input, along with a mathematical
 expression, and combines them to produce a new HDF5 file.
 

--- a/doc/man/h5topng.1.in
+++ b/doc/man/h5topng.1.in
@@ -27,7 +27,7 @@ h5topng \- generate PNG images from 2d slices of HDF5 files
 [\fIOPTION\fR]... [\fIHDF5FILE\fR]...
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5topng is a utility to generate images in PNG (Portable Network Graphics)
 format from two-dimensional slices of datasets in HDF5 files.  It is
 designed for quick-and-dirty visualization of scientific data, and for

--- a/doc/man/h5totxt.1
+++ b/doc/man/h5totxt.1
@@ -27,7 +27,7 @@ h5totxt \- generate comma-delimited text from 2d slices of HDF5 files
 [\fIOPTION\fR]... [\fIHDF5FILE\fR]...
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5totxt is a utility to generate comma-delimited text (and similar
 formats) from one-, two-, or more-dimensional slices of numeric
 datasets in HDF5 files.  This way, the data can easily be imported

--- a/doc/man/h5tov5d.1
+++ b/doc/man/h5tov5d.1
@@ -27,7 +27,7 @@ h5tov5d \- convert datasets in HDF5 files to Vis5d format
 [\fIOPTION\fR]... [\fIHDF5FILE\fR]...
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5tov5d is a program to generate Vis5d data files from
 multidimensional datasets in HDF5 files.  Vis5d is a free volumetric
 visualization program capable of displaying 3, 4, or even 5

--- a/doc/man/h5tovtk.1
+++ b/doc/man/h5tovtk.1
@@ -27,7 +27,7 @@ h5tovtk \- convert datasets in HDF5 files to VTK format
 [\fIOPTION\fR]... [\fIHDF5FILE\fR]...
 .SH DESCRIPTION
 .PP
-." Add any additional description here
+.\" Add any additional description here
 h5tovtk is a program to generate VTK data files from multidimensional
 datasets in HDF5 files.  VTK, the Visualization ToolKit, is an
 open-source, freely available software system for 3D computer


### PR DESCRIPTION
These issues were reported by the lintian QA tool as part of the Debian package build.