### PR TITLE
Correctly parse strings with spaces passed to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,4 +5,4 @@ autoreconf --verbose --install --symlink --force
 autoreconf --verbose --install --symlink --force
 autoreconf --verbose --install --symlink --force
 
-./configure --with-hdf4 --enable-maintainer-mode $*
+./configure --with-hdf4 --enable-maintainer-mode "$@"


### PR DESCRIPTION
This change fixes a problem where trying to do something like
```bash
sh autogen.sh --enable-shared CPPFLAGS="-I/usr/local/include -I/usr/include/hdf5/serial"
```
results in the error
```
configure: error: unrecognized option: `-I/usr/include/hdf5/serial'
```
@oskooi
