### PR TITLE
Don't use \' groff sequence for apostrophe.

### DIFF
--- a/doc/man/h5fromh4.1
+++ b/doc/man/h5fromh4.1
@@ -53,7 +53,7 @@ option is used and multiple HDF4 files are specified, all the HDF4
 datasets are output into that HDF5 file with the input filenames
 (minus the ".hdf" suffix) used as the dataset names.
 
-The most basic usage is something like \'h5fromh4 foo.hdf\', which
+The most basic usage is something like \(aqh5fromh4 foo.hdf\(aq, which
 will output a file foo.h5 containing the scientific dataset from
 foo.hdf.
 .SH OPTIONS

--- a/doc/man/h5topng.1.in
+++ b/doc/man/h5topng.1.in
@@ -49,7 +49,7 @@ slice, via the
 .B -xyzt
 options.  Yet more options control things like the colormap and
 magnification.  Still, the most basic usage is something like
-\'h5topng foo.h5\', which will output a file foo.png containing an
+\(aqh5topng foo.h5\(aq, which will output a file foo.png containing an
 image from the two-dimensional data in foo.h5.
 .SH OPTIONS
 .TP

--- a/doc/man/h5totxt.1
+++ b/doc/man/h5totxt.1
@@ -55,7 +55,7 @@ more slice dimensions, via the
 .B -xyzt
 options.
 
-The most basic usage is something like \'h5totxt foo.h5\', which will
+The most basic usage is something like \(aqh5totxt foo.h5\(aq, which will
 output comma-delimited text to stdout from the data in foo.h5.
 .SH OPTIONS
 .TP

--- a/doc/man/h5tov5d.1
+++ b/doc/man/h5tov5d.1
@@ -56,7 +56,7 @@ more) slice dimension(s), via the
 options.
 
 A typical invocation is of the form
-\'h5tov5d foo.h5\', which will output a Vis5d data file foo.v5d
+\(aqh5tov5d foo.h5\(aq, which will output a Vis5d data file foo.v5d
 from the data in foo.h5.
 .SH OPTIONS
 .TP

--- a/doc/man/h5tovtk.1
+++ b/doc/man/h5tovtk.1
@@ -52,7 +52,7 @@ vectors and fields can be output via the
 option below.
 
 A typical invocation is of the form
-\'h5tovtk foo.h5\', which will output a VTK data file foo.vtk
+\(aqh5tovtk foo.h5\(aq, which will output a VTK data file foo.vtk
 from the data in foo.h5.
 .SH OPTIONS
 .TP


### PR DESCRIPTION
The lintian QA tool reported an issue with the manpages:
> This manual page uses the `\'` groff sequence. Usually, the intent is to generate an apostrophe, but that sequence actually renders as an acute accent.
> 
> For an apostrophe or a single closing quote, use plain `'`. For single opening quote, i.e. a straight downward line `'` like the one used in shell commands, use `'\(aq'`.
> 
> In case this tag was emitted for the second half of a `'\\'` sequence, this is indeed no acute accent, but still wrong: A literal backslash should be written `\e` in the groff format, i.e. a `'\\'` sequence needs to be changed to `'\e'` which also won't trigger this tag.
